### PR TITLE
Moving lint dependency to main.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/udhos/equalfile v0.3.0
-	golang.org/x/tools v0.0.0-20200604042327-9b20fe4cabe8 // indirect
+	golang.org/x/tools v0.0.0-20200604183345-4d5ea46c79fe // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ golang.org/x/tools v0.0.0-20200331202046-9d5940d49312/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200414032229-332987a829c3/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200604042327-9b20fe4cabe8 h1:8Xr1qwxn90MXYKftwNxIO2g4J+26naghxFS5rYiTZww=
-golang.org/x/tools v0.0.0-20200604042327-9b20fe4cabe8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200604183345-4d5ea46c79fe h1:nHJ3EpvC/Nk6Gc4FTwTQ3YOBAODRx412L5jEPjgJcEg=
+golang.org/x/tools v0.0.0-20200604183345-4d5ea46c79fe/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ limitations under the License.
 package main
 
 import (
+	// Adding the golangci-lint import here as a way to insure
+	// that it is installed automatically with a standard version
+	// when we either build the product or run tests.
+	_ "github.com/golangci/golangci-lint/pkg/commands"
 	"github.com/matchstick/exifsort/cmd"
 )
 

--- a/tools/doc.go
+++ b/tools/doc.go
@@ -1,8 +1,0 @@
-// +build tools
-
-//Package tools manages tool dependencies via go.mod.
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-// https://github.com/golang/go/issues/25922
-//
-// nolint
-package tools

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,0 @@
-package tools
-
-import (
-	_ "github.com/golangci/golangci-lint/pkg/commands"
-)


### PR DESCRIPTION
This means we don't need to have the whole directory just for that one import.