### PR TITLE
Fixing up bugs with ScanErrs vs ExifErrs

### DIFF
--- a/lib/ext.go
+++ b/lib/ext.go
@@ -41,7 +41,7 @@ func extensionMap() map[string]int {
 	}
 }
 
-func skipFileType(path string) (string, bool) {
+func skipFileType(path string) bool {
 	// All comparisons are lower case as case don't matter
 	path = strings.ToLower(path)
 
@@ -50,20 +50,20 @@ func skipFileType(path string) (string, bool) {
 	// them.
 	switch {
 	case strings.Contains(path, "@eadir"):
-		return "", true
+		return true
 	case strings.Contains(path, "@syno"):
-		return "", true
+		return true
 	case strings.Contains(path, "synofile_thumb"):
-		return "", true
+		return true
 	}
 
 	extension := filepath.Ext(path)
 	// no extension to check so we skip
 	if extension == "" {
-		return "", true
+		return true
 	}
 
 	_, inExtMap := extensionMap()[extension]
 
-	return extension, !inExtMap
+	return !inExtMap
 }

--- a/lib/ext_test.go
+++ b/lib/ext_test.go
@@ -11,7 +11,7 @@ func TestSkipFileType(t *testing.T) {
 	for extension := range extensionMap() {
 		goodInput := fmt.Sprintf("gobo.%s", extension)
 
-		_, skip := skipFileType(goodInput)
+		skip := skipFileType(goodInput)
 		if skip {
 			t.Errorf("Expected False for %s\n", goodInput)
 		}
@@ -20,7 +20,7 @@ func TestSkipFileType(t *testing.T) {
 	for extension := range extensionMap() {
 		goodInput := strings.ToUpper(fmt.Sprintf("gobo.%s", extension))
 
-		_, skip := skipFileType(goodInput)
+		skip := skipFileType(goodInput)
 		if skip {
 			t.Errorf("Expected False for %s\n", goodInput)
 		}
@@ -30,7 +30,7 @@ func TestSkipFileType(t *testing.T) {
 	for extension := range extensionMap() {
 		goodInput := fmt.Sprintf("hey.gobo.%s", extension)
 
-		_, skip := skipFileType(goodInput)
+		skip := skipFileType(goodInput)
 		if skip {
 			t.Errorf("Expected False for %s\n", goodInput)
 		}
@@ -38,14 +38,14 @@ func TestSkipFileType(t *testing.T) {
 
 	badInput := "gobobob.."
 
-	_, skip := skipFileType(badInput)
+	skip := skipFileType(badInput)
 	if !skip {
 		t.Errorf("Expected True for %s\n", badInput)
 	}
 
 	badInput = "gobo"
 
-	_, skip = skipFileType(badInput)
+	skip = skipFileType(badInput)
 	if !skip {
 		t.Errorf("Expected True for %s\n", badInput)
 	}
@@ -54,7 +54,7 @@ func TestSkipFileType(t *testing.T) {
 	for extension := range extensionMap() {
 		badInput := fmt.Sprintf("gobo.%s..", extension)
 
-		_, skip := skipFileType(badInput)
+		skip := skipFileType(badInput)
 		if !skip {
 			t.Errorf("Expected True for %s\n", badInput)
 		}
@@ -64,21 +64,21 @@ func TestSkipFileType(t *testing.T) {
 func TestSkipSynologyTypes(t *testing.T) {
 	badInput := "@eaDir"
 
-	_, skip := skipFileType(badInput)
+	skip := skipFileType(badInput)
 	if !skip {
 		t.Errorf("Expected True for %s\n", badInput)
 	}
 
 	badInput = "@syno"
 
-	_, skip = skipFileType(badInput)
+	skip = skipFileType(badInput)
 	if !skip {
 		t.Errorf("Expected True for %s\n", badInput)
 	}
 
 	badInput = "synofile_thumb"
 
-	_, skip = skipFileType(badInput)
+	skip = skipFileType(badInput)
 	if !skip {
 		t.Errorf("Expected True for %s\n", badInput)
 	}

--- a/lib/merge.go
+++ b/lib/merge.go
@@ -92,8 +92,7 @@ func MergeCheck(root string, method int) error {
 				return nil
 			}
 
-			_, skip := skipFileType(path)
-			if skip {
+			if skipFileType(path) {
 				return nil
 			}
 
@@ -164,8 +163,7 @@ func Merge(srcRoot string, dstRoot string, method int, logger io.Writer) error {
 				return nil
 			}
 
-			_, skip := skipFileType(srcFile)
-			if skip {
+			if skipFileType(srcFile) {
 				return nil
 			}
 


### PR DESCRIPTION
Making changes to tighten code path for the relationship between modtimes and
exif times. Fixed a bug where we might have used the wrong timeval.

Cleaned up some code paths to be more obvious.

Also cleaned up the types of errors too. So a scan error is not mistakenly
counted as an exif error.