### PR TITLE
Merge bugs and improving merge tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/udhos/equalfile v0.3.0
-	golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2 // indirect
+	golang.org/x/tools v0.0.0-20200612220849-54c614fe050c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,8 @@ golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770 h1:M9Fif0OxNji8w+HvmhVQ8KJ
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2 h1:DVqHa33CzfnTKwUV6be+I4hp31W6iXn3ZiEcdKGzLyI=
 golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200612220849-54c614fe050c h1:g6oFfz6Cmw68izP3xsdud3Oxu145IPkeFzyRg58AKHM=
+golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,6 @@ golang.org/x/tools v0.0.0-20200414032229-332987a829c3/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770 h1:M9Fif0OxNji8w+HvmhVQ8KJtiZOsjU9RgslJGhn95XE=
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2 h1:DVqHa33CzfnTKwUV6be+I4hp31W6iXn3ZiEcdKGzLyI=
-golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200612220849-54c614fe050c h1:g6oFfz6Cmw68izP3xsdud3Oxu145IPkeFzyRg58AKHM=
 golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/lib/merge_test.go
+++ b/lib/merge_test.go
@@ -16,7 +16,7 @@ Think of all test cases:
 */
 func TestMergeCheckGood(t *testing.T) {
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
+		td := newTestDir(t, method, fileNoDefault)
 
 		src := td.buildRoot()
 		defer os.RemoveAll(src)
@@ -34,7 +34,7 @@ func TestMergeCheckGood(t *testing.T) {
 
 func TestMergeCheckBad(t *testing.T) {
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
+		td := newTestDir(t, method, fileNoDefault)
 
 		src := td.buildRoot()
 		defer os.RemoveAll(src)
@@ -57,11 +57,11 @@ func TestMergeCheckBad(t *testing.T) {
 }
 
 func testMerge(t *testing.T, method int, action int, dstFileNo int, dup bool) error {
-	tdSrc := newTestDir(t, method)
-	tdDst := newTestDir(t, method)
+	tdSrc := newTestDir(t, method, fileNoDefault)
+	tdDst := newTestDir(t, method, fileNoDefault)
 
 	// If we want to not have duplicate testdirs we need to modify the fileNo
-	if dstFileNo != 0 {
+	if dstFileNo != fileNoDefault {
 		tdDst.setFileNo(dstFileNo)
 	}
 
@@ -142,9 +142,9 @@ func TestMergeGood(t *testing.T) {
 }
 
 func TestMergeDuplicate(t *testing.T) {
-	// By setting the fileNo to 0 we ensure the dst directory will have
+	// By setting the fileNo to the default we ensure the dst directory will have
 	// files with the same names as src and then get duplicates.
-	fileNo := 0
+	fileNo := fileNoDefault
 
 	for method := MethodYear; method < MethodNone; method++ {
 		err := testMerge(t, method, ActionCopy, fileNo, true)

--- a/lib/merge_test.go
+++ b/lib/merge_test.go
@@ -1,6 +1,7 @@
 package exifsort
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -55,37 +56,109 @@ func TestMergeCheckBad(t *testing.T) {
 	}
 }
 
-func TestMergeDuplicate(t *testing.T) {
+func testMerge(t *testing.T, method int, action int, dstFileNo int, dup bool) error {
+	tdSrc := newTestDir(t, method)
+	tdDst := newTestDir(t, method)
+
+	// If we want to not have duplicate testdirs we need to modify the fileNo
+	if dstFileNo != 0 {
+		tdDst.setFileNo(dstFileNo)
+	}
+
+	src := tdSrc.buildRoot()
+	dst := tdDst.buildRoot()
+
+	// Copy files to two sorted directories that are identical
+	fromDir := tdSrc.buildSortedDir(src, "fromDir_", ActionCopy)
+	toDir := tdDst.buildSortedDir(dst, "toDir_", ActionCopy)
+
+	// merge them
+	err := Merge(fromDir, toDir, action, ioutil.Discard)
+	if err != nil {
+		return err
+	}
+
+	var leftOvers int
+
+	switch action {
+	case ActionCopy:
+		// src dir should have all its media untouched
+		leftOvers = tdSrc.numTotal()
+	case ActionMove:
+		// src dir should have all media merged and be empty
+		leftOvers = 0
+	default:
+		return errors.New("unknown action")
+	}
+
+	err = countFiles(t, fromDir, leftOvers, "Src Dir")
+	if err != nil {
+		return err
+	}
+
+	var total int
+	if dup {
+		// Destination should have data only from dst as src is all duplicates
+		total = tdDst.numData
+	} else {
+		// Destination should have all data from both sources
+		total = tdDst.numData + tdSrc.numData
+	}
+
+	err = countFiles(t, toDir, total, "Target Dir")
+	if err != nil {
+		return err
+	}
+
+	defer os.RemoveAll(fromDir)
+	defer os.RemoveAll(toDir)
+	defer os.RemoveAll(src)
+
+	return nil
+}
+
+func TestMergeGood(t *testing.T) {
+	// By setting the fileNo so high the files will have different names
+	// between tesdirs We are hoping that this number is just high enough
+	// but as of this writing testdir has 150 files, and our countfiles
+	// checking should protect us.
+	fileNo := 10000
+
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
-
-		src := td.buildRoot()
-
-		// COpy files to two sorted directories that are identical
-		fromDir := td.buildSortedDir(src, "fromDir_", ActionCopy)
-		toDir := td.buildSortedDir(src, "toDir_", ActionCopy)
-
-		// merge them
-		err := Merge(fromDir, toDir, ActionMove, ioutil.Discard)
+		err := testMerge(t, method, ActionCopy, fileNo, false)
 		if err != nil {
-			t.Errorf("Error %s", err.Error())
+			t.Fatalf("Method %d, Action Copy Error: %s\n",
+				method, err.Error())
 		}
+	}
 
-		// Source should have all its files removed as they are all
-		// duplicates
-		err = countFiles(t, fromDir, 0, "Src Dir")
+	for method := MethodYear; method < MethodNone; method++ {
+		err := testMerge(t, method, ActionMove, fileNo, false)
 		if err != nil {
-			t.Errorf("Error %s", err.Error())
+			t.Fatalf("Method %d, Action Move Error: %s\n",
+				method, err.Error())
 		}
+	}
+}
 
-		// Destination should have all its original contents
-		err = countFiles(t, toDir, td.numTotal(), "Target Dir")
+func TestMergeDuplicate(t *testing.T) {
+	// By setting the fileNo to 0 we ensure the dst directory will have
+	// files with the same names as src and then get duplicates.
+	fileNo := 0
+
+	for method := MethodYear; method < MethodNone; method++ {
+		err := testMerge(t, method, ActionCopy, fileNo, true)
 		if err != nil {
-			t.Errorf("Error %s", err.Error())
+			t.Fatalf("Method %d, Action Copy Error: %s\n",
+				method, err.Error())
 		}
+	}
 
-		os.RemoveAll(fromDir)
-		os.RemoveAll(toDir)
-		os.RemoveAll(src)
+	for method := MethodYear; method < MethodNone; method++ {
+		err := testMerge(t, method, ActionMove, fileNo, true)
+		if err != nil {
+			t.Fatalf("Method %d, Action Move Error: %s\n",
+				method, err.Error())
+		}
 	}
 }

--- a/lib/scanner_test.go
+++ b/lib/scanner_test.go
@@ -112,7 +112,7 @@ func testCheckScanCounts(t *testing.T, td *testdir, s Scanner) {
 }
 
 func TestScanDir(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildRoot()
 	defer os.RemoveAll(tmpPath)
@@ -124,7 +124,7 @@ func TestScanDir(t *testing.T) {
 }
 
 func TestScanSkipDir(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildSkipRoot()
 	defer os.RemoveAll(tmpPath)
@@ -140,7 +140,7 @@ func TestScanBadDir(t *testing.T) {
 		return
 	}
 
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildBadRoot()
 	defer os.RemoveAll(tmpPath)
@@ -152,7 +152,7 @@ func TestScanBadDir(t *testing.T) {
 }
 
 func TestScanSaveLoad(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildRoot()
 	defer os.RemoveAll(tmpPath)
@@ -183,7 +183,7 @@ func TestScanSaveLoad(t *testing.T) {
 }
 
 func TestScanBadSave(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildRoot()
 	defer os.RemoveAll(tmpPath)
@@ -210,7 +210,7 @@ func TestScanBadSave(t *testing.T) {
 }
 
 func TestScanBadLoad(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	tmpPath := td.buildRoot()
 	defer os.RemoveAll(tmpPath)

--- a/lib/sorter_test.go
+++ b/lib/sorter_test.go
@@ -53,7 +53,7 @@ func testTransfer(t *testing.T, td *testdir, method int, action int) error {
 
 func TestSortDir(t *testing.T) {
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
+		td := newTestDir(t, method, fileNoDefault)
 
 		src := td.buildRoot()
 		defer os.RemoveAll(src)
@@ -72,7 +72,7 @@ func TestSortDir(t *testing.T) {
 
 func TestSortDuplicates(t *testing.T) {
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
+		td := newTestDir(t, method, fileNoDefault)
 
 		src := td.buildDuplicateRoot()
 		defer os.RemoveAll(src)
@@ -91,7 +91,7 @@ func TestSortDuplicates(t *testing.T) {
 
 func TestSortCollisions(t *testing.T) {
 	for method := MethodYear; method < MethodNone; method++ {
-		td := newTestDir(t, method)
+		td := newTestDir(t, method, fileNoDefault)
 
 		src := td.buildCollisionRoot()
 		defer os.RemoveAll(src)
@@ -111,7 +111,7 @@ func TestSortCollisions(t *testing.T) {
 func TestBadSortMethod(t *testing.T) {
 	const badMethod = 888
 
-	td := newTestDir(t, badMethod)
+	td := newTestDir(t, badMethod, fileNoDefault)
 
 	err := testTransfer(t, td, badMethod, ActionMove)
 	if err == nil {
@@ -122,7 +122,7 @@ func TestBadSortMethod(t *testing.T) {
 func TestBadSortAction(t *testing.T) {
 	const badAction = 888
 
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	err := testTransfer(t, td, MethodYear, badAction)
 	if err == nil {
@@ -131,7 +131,7 @@ func TestBadSortAction(t *testing.T) {
 }
 
 func TestSortNoOutputDir(t *testing.T) {
-	td := newTestDir(t, MethodNone)
+	td := newTestDir(t, MethodNone, fileNoDefault)
 
 	src := td.buildRoot()
 	defer os.RemoveAll(src)

--- a/lib/testdir_test.go
+++ b/lib/testdir_test.go
@@ -86,6 +86,26 @@ func countFiles(t *testing.T, path string, correctCount int, label string) error
 	return nil
 }
 
+/*
+
+Helpful for debugging.
+
+func listDir(root string) {
+	_ = filepath.Walk(root,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			fmt.Print(path + "\n")
+			return nil
+		})
+}
+*/
 type testdir struct {
 	fileNo    int // We want files that are unique across an entire testdir instance
 	root      string

--- a/lib/testdir_test.go
+++ b/lib/testdir_test.go
@@ -29,6 +29,7 @@ const (
 	noRootExifPath = "../data/no_root_ifd.jpg"
 	skipPath       = "../README.md"
 	nonesensePath  = "../gobofragggle"
+	fileNoDefault  = 0
 )
 
 func countFiles(t *testing.T, path string, correctCount int, label string) error {
@@ -317,10 +318,10 @@ func (td *testdir) buildSortedDir(src string, dst string, action int) string {
 	return dst
 }
 
-func newTestDir(t *testing.T, method int) *testdir {
+func newTestDir(t *testing.T, method int, fileNo int) *testdir {
 	var td testdir
 
-	td.fileNoStart = 0
+	td.fileNoStart = fileNo
 	td.fileNo = 0
 	td.root, _ = ioutil.TempDir("", "root")
 	td.t = t


### PR DESCRIPTION
Fixing a bug in non unique filenames for duplicates.
Improving merge test code immensely. Now it is clear and errors that were hidden are now obvious.

Improvements to testdir also. 