### PR TITLE
Fixing TestMergeFilter

### DIFF
--- a/lib/merger_test.go
+++ b/lib/merger_test.go
@@ -405,3 +405,33 @@ func TestMergeMethodMultiple(t *testing.T) {
 		t.Errorf("Succes is unexpected. src and dst have the different methods\n")
 	}
 }
+
+func TestMergeFilter(t *testing.T) {
+	for _, method := range Methods() {
+		method := method
+
+		t.Run(method.String(), func(t *testing.T) {
+			t.Parallel()
+
+			err := testMergeFilter(t, method, ActionCopy)
+			if err != nil {
+				t.Fatalf("Method %s, Action Copy Error: %s\n",
+					method, err.Error())
+			}
+		})
+	}
+
+	for _, method := range Methods() {
+		method := method
+
+		t.Run(method.String(), func(t *testing.T) {
+			t.Parallel()
+
+			err := testMergeFilter(t, method, ActionMove)
+			if err != nil {
+				t.Fatalf("Method %s, Action Move Error: %s\n",
+					method, err.Error())
+			}
+		})
+	}
+}

--- a/lib/merger_unix_test.go
+++ b/lib/merger_unix_test.go
@@ -81,33 +81,3 @@ func TestMergePathBad(t *testing.T) {
 		}
 	}
 }
-
-func TestMergeFilter(t *testing.T) {
-	for _, method := range Methods() {
-		method := method
-
-		t.Run(method.String(), func(t *testing.T) {
-			t.Parallel()
-
-			err := testMergeFilter(t, method, ActionCopy)
-			if err != nil {
-				t.Fatalf("Method %s, Action Copy Error: %s\n",
-					method, err.Error())
-			}
-		})
-	}
-
-	for _, method := range Methods() {
-		method := method
-
-		t.Run(method.String(), func(t *testing.T) {
-			t.Parallel()
-
-			err := testMergeFilter(t, method, ActionMove)
-			if err != nil {
-				t.Fatalf("Method %s, Action Move Error: %s\n",
-					method, err.Error())
-			}
-		})
-	}
-}

--- a/lib/merger_unix_test.go
+++ b/lib/merger_unix_test.go
@@ -84,18 +84,30 @@ func TestMergePathBad(t *testing.T) {
 
 func TestMergeFilter(t *testing.T) {
 	for _, method := range Methods() {
-		err := testMergeFilter(t, method, ActionCopy)
-		if err != nil {
-			t.Fatalf("Method %s, Action Copy Error: %s\n",
-				method, err.Error())
-		}
+		method := method
+
+		t.Run(method.String(), func(t *testing.T) {
+			t.Parallel()
+
+			err := testMergeFilter(t, method, ActionCopy)
+			if err != nil {
+				t.Fatalf("Method %s, Action Copy Error: %s\n",
+					method, err.Error())
+			}
+		})
 	}
 
 	for _, method := range Methods() {
-		err := testMergeFilter(t, method, ActionMove)
-		if err != nil {
-			t.Fatalf("Method %s, Action Move Error: %s\n",
-				method, err.Error())
-		}
+		method := method
+
+		t.Run(method.String(), func(t *testing.T) {
+			t.Parallel()
+
+			err := testMergeFilter(t, method, ActionMove)
+			if err != nil {
+				t.Fatalf("Method %s, Action Move Error: %s\n",
+					method, err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
TestMergeFilter now runs in parallel and runs portably as opposed to only Windows.